### PR TITLE
修复代码块优化的复制功能

### DIFF
--- a/src/modules/code-block-ex.js
+++ b/src/modules/code-block-ex.js
@@ -36,7 +36,7 @@ mod.reg_hook_new("code-block-ex", "代码块优化", "@/.*", {
                     if ($btn.text() !== "复制") return // Note: Debounce
                     $btn.text("复制成功").toggleClass("exlg-copied")
                     setTimeout(() => $btn.text("复制").toggleClass("exlg-copied"), 800)
-                    GM_setClipboard($pre.text(), { type: "text", mimetype: "text/plain" })
+                    GM_setClipboard($pre.text(), "text/plain")
                 })
 
         const $code = $pre.children("code")


### PR DESCRIPTION
```
^M code-block-ex
 : 现在使用 Violentmonkey 管理用户脚本时可以正常复制代码。
```

根据文档，Violentmonkey 控制剪贴板是 `GM_setClipboard(data, type)`，其中 `type` 只支持 `string`，而 Tampermonkey 则是 `GM_setClipboard(data, info)`，`info` 既可以是对象，又可以是 `string`。

原代码中使用了对象来表达类型，导致 Violentmonkey 用户无法复制代码块。

参考：

- https://violentmonkey.github.io/api/gm/#gm_setclipboard
- https://www.tampermonkey.net/documentation.php#GM_setClipboard