### PR TITLE
Fix the bug of `console.info`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -364,8 +364,9 @@ const mod = {
             }
         }
 
+        const oldConsoleInfo = console.info.bind({}); // Note: 拷贝一个 console.info 防止在 Violentmonkey 中的无限递归
         uindow.console.info = (content) => {
-            const event = console.info(content);
+            const event = oldConsoleInfo(content);
             log(`info hooked: ${content}`);
             if (content === "[@lfe/loader]") {
                 for (const [modName, m] of mod._.entries()) {


### PR DESCRIPTION
> 使用 Violentmonkey 管理脚本时，不会再出现 console.info 报错的情况。

https://github.com/extend-luogu/extend-luogu/blob/ab5ab87d2260b6c7e5056467f6bbc3e1c5dfd440/src/core.js#L367-L369

这里 Violentmonkey 会认为两个 console.info 是同一个，导致了无限递归。

顺便解决了 #222 中网页 url 无更新的问题。