### PR TITLE
修复帖子保存站的域名

### DIFF
--- a/src/resources/tm-headers.js
+++ b/src/resources/tm-headers.js
@@ -18,7 +18,7 @@
 // @include        http://localhost:1634/*
 //
 // @connect        tencentcs.com
-// @connect        https://fx白丝.ml/
+// @connect        xn--fx-ex2c330n.ml
 // @connect        bens.rotriw.com
 // @connect        codeforces.com
 // @connect        codeforces.ml


### PR DESCRIPTION
中文域名在部分油猴上无法正确作用，此处改为使用 punny code.