### PR TITLE
增加GM_addElement的兼容性

### DIFF
--- a/src/core/utils/utils.ts
+++ b/src/core/utils/utils.ts
@@ -24,14 +24,12 @@ export { Schema }
 
 unsafeWindow.$ ??= $
 
-function addElement(tagName: string, attributes: object): void {
-    if (typeof GM_addElement === 'function') {
-        GM_addElement(tagName, attributes)
-    } else {
+function addElement = (typeof GM_addElement === 'function') ?
+    (tagName, attributes) => GM_addElement(tagName, attributes)
+    : (tagName, attributes) => {
         const e = document.createElement(tagName)
         document.head.appendChild(Object.assign(e, attributes))
     }
-}
 
 export const loadJs = (js: string) => {
     addElement('script', { textContent: js })

--- a/src/core/utils/utils.ts
+++ b/src/core/utils/utils.ts
@@ -24,12 +24,21 @@ export { Schema }
 
 unsafeWindow.$ ??= $
 
+function addElement(tagName: string, attributes: object): void {
+    if (typeof GM_addElement === 'function') {
+        GM_addElement(tagName, attributes)
+    } else {
+        const e = document.createElement(tagName)
+        document.head.appendChild(Object.assign(e, attributes))
+    }
+}
+
 export const loadJs = (js: string) => {
-    GM_addElement('script', { textContent: js })
+    addElement('script', { textContent: js })
 }
 
 export const loadCss = (css: string) => {
-    GM_addElement('style', { textContent: css })
+    addElement('style', { textContent: css })
 }
 
 export function chain<T>(res: Promise<T>): Promise<T> {

--- a/src/core/utils/utils.ts
+++ b/src/core/utils/utils.ts
@@ -7,6 +7,10 @@ import { Schema } from '../storage'
 import type { ExecuteState } from '../module'
 
 declare global {
+    // TamperMonkey
+
+    function GM_addElement(tagName: string, attributes: object): void
+
     // Luogu
 
     const _feInjection: any


### PR DESCRIPTION
GM_addElement的目的是添加script, link, style元素当他们被Content-Security-Policy所禁止。
删除GM_addElement这个实验性api，以增加兼容性（可以兼容现版本scriptcat）