### PR TITLE
修了一些dashboard的bug

### DIFF
--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -83,13 +83,21 @@ exlg.modules['${module.id}'].runtime.setWrapper(function(
 `
 
 export const installModule = (metadata: ModuleMetadata, script: string) => {
+    const id = `${metadata.source}:${metadata.name}`
+
     const module: ModuleReadonly = {
-        id: `${metadata.source}:${metadata.name}`,
+        id,
         active: true,
         metadata,
         script
     }
-    storage.set(module.id, module)
+    storage.set(id, module)
+    const { modules } = unsafeWindow.exlg
+    modules[id] = {
+        ...module,
+        runtime: { interfaces: {} }
+    }
+    modules[id].runtime.executeState = executeModule(modules[id])
 }
 
 export const executeModule = async (module: Module): Promise<ExecuteState> => {

--- a/src/dash/src/components/views/ModuleCtlView.vue
+++ b/src/dash/src/components/views/ModuleCtlView.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { inject, ref } from 'vue'
-import type { ModulesReadonly, ExecuteState } from '@core/types'
+import type { ModulesReadonly } from '@core/types'
 import {
     kModuleCtl,
     kShowConfig,
     kShowInterface
 } from '@/utils/injectionSymbols'
-import Await from '@comp/utils/Await.vue'
+// import Await from '@comp/utils/Await.vue'
 import TextCheckbox from '@comp/utils/TextCheckbox.vue'
+import ModuleState from './ModuleState.vue'
 
 const emits = defineEmits<{
     (e: 'uninstallModule', id: string): void
@@ -41,26 +42,6 @@ function uninstall(id: string) {
     })
 }
 
-const executeStateIcons: Record<ExecuteState, string> = {
-    done: '✨',
-    threw: '💥',
-    inactive: '❄️',
-    mismatched: '🌙',
-    storageBroken: '💥',
-    notExported: '💥',
-    unwrapThrew: '💥'
-}
-
-const executeStateTexts: Record<ExecuteState, string> = {
-    done: '已加载',
-    threw: '出错了',
-    inactive: '未开启',
-    mismatched: '未匹配',
-    storageBroken: '数据错误',
-    notExported: '无导出',
-    unwrapThrew: '解包错误'
-}
-
 updateModuleCache()
 
 defineExpose({
@@ -75,15 +56,16 @@ const showId = ref(false)
         <div>
             <TextCheckbox text="🆔" title="显示 ID" v-model="showId" />
             <ul class="module-list">
-                <li v-for="mod of modulesRo" :key="mod.id" class="module-entry">
+                <li v-for="mod in modulesRo" :key="mod.id" class="module-entry">
                     <span>
-                        <Await
+                        <ModuleState :mod="modules[mod.id]"></ModuleState>
+                        <!-- <Await
                             :promise="modules[mod.id]?.runtime?.executeState"
                         >
                             <template #first>🕒</template>
-                            <template #then="{ result }">
-                                <!-- FIXME: <https://segmentfault.com/q/1010000042083565> -->
-                                <span
+                            <template #then="{ result }"> -->
+                        <!-- FIXME: <https://segmentfault.com/q/1010000042083565> -->
+                        <!-- <span
                                     class="execute-state exlg-tooltip"
                                     :data-exlg-tooltip="
                                         /* @ts-expect-error */
@@ -96,7 +78,7 @@ const showId = ref(false)
                                     }}
                                 </span>
                             </template>
-                        </Await>
+                        </Await> -->
                         {{ showId ? mod.id : mod.metadata.display }}
                         <span class="module-version">
                             @{{ mod.metadata.version }}

--- a/src/dash/src/components/views/ModuleCtlView.vue
+++ b/src/dash/src/components/views/ModuleCtlView.vue
@@ -105,8 +105,9 @@ const showId = ref(false)
                     <span style="white-space: nowrap">
                         <span
                             v-if="
-                                Object.keys(modules[mod.id].runtime.interfaces)
-                                    .length
+                                Object.keys(
+                                    modules[mod.id]?.runtime?.interfaces ?? {}
+                                ).length
                             "
                             class="emoji-button"
                             title="执行命令"

--- a/src/dash/src/components/views/ModuleCtlView.vue
+++ b/src/dash/src/components/views/ModuleCtlView.vue
@@ -55,6 +55,9 @@ const showId = ref(false)
     <div class="root">
         <div>
             <TextCheckbox text="🆔" title="显示 ID" v-model="showId" />
+
+            <hr class="exlg-hr" />
+
             <ul class="module-list">
                 <li v-for="mod in modulesRo" :key="mod.id" class="module-entry">
                     <span>
@@ -143,13 +146,5 @@ const showId = ref(false)
 .emoji-button {
     user-select: none;
     cursor: pointer;
-}
-
-.execute-state {
-    user-select: none;
-}
-.execute-state:after {
-    right: 100%;
-    width: max-content;
 }
 </style>

--- a/src/dash/src/components/views/ModuleState.vue
+++ b/src/dash/src/components/views/ModuleState.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useAsyncState } from '@/utils'
+import type { ExecuteState, Module } from '@core/types'
+
+const executeStateIcons: Record<ExecuteState, string> = {
+    done: '✨',
+    threw: '💥',
+    inactive: '❄️',
+    mismatched: '🌙',
+    storageBroken: '💥',
+    notExported: '💥',
+    unwrapThrew: '💥'
+}
+
+const executeStateTexts: Record<ExecuteState, string> = {
+    done: '已加载',
+    threw: '出错了',
+    inactive: '未开启',
+    mismatched: '未匹配',
+    storageBroken: '数据错误',
+    notExported: '无导出',
+    unwrapThrew: '解包错误'
+}
+
+const props = defineProps<{
+    mod?: Module
+}>()
+
+const state = props.mod?.runtime?.executeState
+    ? useAsyncState(props.mod?.runtime?.executeState)
+    : null
+</script>
+
+<template>
+    <template v-if="state !== null">
+        <span v-if="state.isLoading.value === true">🕒</span>
+        <span
+            v-if="state.isReady.value === true"
+            class="execute-state exlg-tooltip"
+            :data-exlg-tooltip="executeStateTexts[state.state.value ?? 'threw']"
+        >
+            {{ executeStateIcons[state.state.value ?? 'threw'] }}
+        </span>
+    </template>
+</template>

--- a/src/dash/src/components/views/ModuleState.vue
+++ b/src/dash/src/components/views/ModuleState.vue
@@ -43,3 +43,13 @@ const state = props.mod?.runtime?.executeState
         </span>
     </template>
 </template>
+
+<style>
+.execute-state {
+    user-select: none;
+}
+.execute-state:after {
+    right: 100%;
+    width: max-content;
+}
+</style>

--- a/src/dash/src/utils/index.ts
+++ b/src/dash/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { ref, UnwrapRef } from 'vue'
+
 export enum InstallState {
     uninstalled,
     installed,
@@ -20,3 +22,35 @@ export interface NpmSourceItem extends SourceItem {
 }
 export type AllSourceItem = NpmSourceItem
 export type Source = AllSourceItem[]
+
+export function useAsyncState<T>(promise: Promise<T>, initialState?: T) {
+    const state = ref(initialState)
+    const isReady = ref(false)
+    const isLoading = ref(false)
+    const error = ref<unknown>(undefined)
+
+    async function execute() {
+        error.value = undefined
+        isReady.value = false
+        isLoading.value = true
+
+        try {
+            const data = await promise
+            state.value = data as UnwrapRef<T>
+            isReady.value = true
+        } catch (e) {
+            error.value = e
+        }
+
+        isLoading.value = false
+    }
+
+    execute()
+
+    return {
+        state,
+        isReady,
+        isLoading,
+        error
+    }
+}


### PR DESCRIPTION
1. 修复下载后有个Undefined的bug (Fixed #343 )。复现方法，旧版exlg-celeste点击下载任一模块后，状态一直显示`[安装中]`，此时点击dashboard上的`模块`或`开发选项`都没有反应，控制台中出现error。
2. 修复点击下载后，`模块`tab中的state图标显示的异常（原来因第一点，所以看不见）。
（为什么exlg-celeste一直在咕咕咕）